### PR TITLE
add cmake build support

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,133 @@
+name: Build VCV Rack Plugin
+on: [push, pull_request]
+
+env:
+  rack-sdk-version: 2.2.3
+  rack-plugin-toolchain-dir: /home/build/rack-plugin-toolchain
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  modify-plugin-version:
+    name: Modify plugin version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: plugin-version-cache
+        with:
+          path: plugin.json
+          key: ${{ github.sha }}-${{ github.run_id }}
+      - run: |
+          gitrev=`git rev-parse --short HEAD`
+          pluginversion=`jq -r '.version' plugin.json`
+          echo "Set plugin version from $pluginversion to $pluginversion-$gitrev"
+          cat <<< `jq --arg VERSION "$pluginversion-$gitrev" '.version=$VERSION' plugin.json` > plugin.json
+        # only modify plugin version if no tag was created
+        if: "! startsWith(github.ref, 'refs/tags/v')"
+
+  build:
+    name: ${{ matrix.platform }}
+    needs: modify-plugin-version
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/qno/rack-plugin-toolchain-win-linux
+      options: --user root
+    strategy:
+      matrix:
+        platform: [win-x64, linux-x64]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/cache@v3
+        id: plugin-version-cache
+        with:
+          path: plugin.json
+          key: ${{ github.sha }}-${{ github.run_id }}
+      - name: Build plugin
+        run: |
+          export PLUGIN_DIR=$GITHUB_WORKSPACE
+          pushd ${{ env.rack-plugin-toolchain-dir }}
+          make plugin-build-${{ matrix.platform }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.rack-plugin-toolchain-dir }}/plugin-build
+          name: ${{ matrix.platform }}
+
+  build-mac:
+    name: mac
+    needs: modify-plugin-version
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, arm64]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/cache@v3
+        id: plugin-version-cache
+        with:
+          path: plugin.json
+          key: ${{ github.sha }}-${{ github.run_id }}
+      - name: Get Rack-SDK
+        run: |
+          pushd $HOME
+          curl -o Rack-SDK.zip https://vcvrack.com/downloads/Rack-SDK-${{ env.rack-sdk-version }}-mac-${{ matrix.platform }}.zip
+          unzip Rack-SDK.zip
+      - name: Build plugin
+        run: |
+          CROSS_COMPILE_TARGET_x64=x86_64-apple-darwin
+          CROSS_COMPILE_TARGET_arm64=arm64-apple-darwin
+          export RACK_DIR=$HOME/Rack-SDK
+          export CROSS_COMPILE=$CROSS_COMPILE_TARGET_${{ matrix.platform }}
+          make dep
+          make dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.vcvplugin
+          name: mac-${{ matrix.platform }}
+
+  publish:
+    name: Publish plugin
+    # only create a release if a tag was created that is called e.g. v1.2.3
+    # see also https://vcvrack.com/manual/Manifest#version
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs:  [build, build-mac]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: FranzDiebold/github-env-vars-action@v2
+      - name: Check if plugin version matches tag
+        run: |
+          pluginversion=`jq -r '.version' plugin.json`
+          if [ "v$pluginversion" != "${{ env.CI_REF_NAME }}" ]; then
+            echo "Plugin version from plugin.json 'v$pluginversion' doesn't match with tag version '${{ env.CI_REF_NAME }}'"
+            exit 1
+          fi
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ env.CI_REF_NAME }}
+          body: |
+            ${{ env.CI_REPOSITORY_NAME }} VCV Rack Plugin ${{ env.CI_REF_NAME }}
+          draft: false
+          prerelease: false
+      - uses: actions/download-artifact@v3
+        with:
+          path: _artifacts
+      - name: Upload release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _artifacts/**/*.vcvplugin
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_CXX_STANDARD 17)
 project(vcv-svghelper)
 
 set(PLUGIN_NAME ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,10 @@
-# compile src/*.cpp including include/*.hpp
-
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.16)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 project(vcv-svghelper)
 
-set(CMAKE_CXX_STANDARD 17)
+set(PLUGIN_NAME ${PROJECT_NAME})
+set(ADDITIONAL_PLUGIN_DISTRIBUTABLES README.md)
+include(RackSDK.cmake)
 
-set(RACK_SDK_DIR "B:/code/Rack/Rack-SDK" CACHE PATH "Path to Rack SDK")
-
-## include Rack SDK headers
-include_directories(include)
-include_directories(${RACK_SDK_DIR}/include)
-include_directories(${RACK_SDK_DIR}/dep/include)
-
-## compile src
-file(GLOB_RECURSE SRC_FILES src/*.cpp)
-add_library(vcv-svghelper STATIC ${SRC_FILES})
-
-
-## link against Rack SDK static library
-
-if (WIN32)
-	target_link_libraries(vcv-svghelper INTERFACE ${RACK_SDK_DIR}/libRack.dll.a)
-else()
-	target_link_libraries(vcv-svghelper INTERFACE ${RACK_SDK_DIR}/librack.a)
-endif()
-
-add_executable(dummy main.cpp)
-target_link_libraries(dummy vcv-svghelper)
+target_include_directories(${RACK_PLUGIN_LIB} PRIVATE include)
+target_sources(${RACK_PLUGIN_LIB} PRIVATE src/SvgHelper.cpp)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# If RACK_DIR is not defined when calling the Makefile, default to two directories above
+RACK_DIR ?= ../..
+include $(RACK_DIR)/arch.mk
+
+EXTRA_CMAKE :=
+RACK_PLUGIN_NAME := plugin
+RACK_PLUGIN_ARCH :=
+RACK_PLUGIN_EXT := so
+
+ifdef ARCH_WIN
+  RACK_PLUGIN_EXT := dll
+endif
+
+ifdef ARCH_MAC
+  EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="x86_64"
+  RACK_PLUGIN_EXT := dylib
+  ifdef ARCH_ARM64
+    EXTRA_CMAKE := -DCMAKE_OSX_ARCHITECTURES="arm64"
+    RACK_PLUGIN_ARCH := -arm64
+  endif
+endif
+
+RACK_PLUGIN := $(RACK_PLUGIN_NAME)$(RACK_PLUGIN_ARCH).$(RACK_PLUGIN_EXT)
+
+CMAKE_BUILD ?= dep/cmake-build
+cmake_rack_plugin := $(CMAKE_BUILD)/$(RACK_PLUGIN)
+
+# create empty plugin lib to skip the make target execution
+$(shell touch $(RACK_PLUGIN))
+$(info cmake_rack_plugin target is '$(cmake_rack_plugin)')
+
+# trigger CMake build when running `make dep`
+DEPS += $(cmake_rack_plugin)
+
+$(cmake_rack_plugin): CMakeLists.txt
+	$(CMAKE) -B $(CMAKE_BUILD) -DRACK_SDK_DIR=$(RACK_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CMAKE_BUILD)/dist $(EXTRA_CMAKE)
+	cmake --build $(CMAKE_BUILD) -- -j $(shell getconf _NPROCESSORS_ONLN)
+	cmake --install $(CMAKE_BUILD)
+
+rack_plugin: $(cmake_rack_plugin)
+	cp -vf $(cmake_rack_plugin) .
+
+dist: rack_plugin res
+
+# The compiled plugin and "plugin.json" are automatically added.
+DISTRIBUTABLES += res
+DISTRIBUTABLES += $(wildcard LICENSE*)
+
+# Include the Rack plugin Makefile framework
+include $(RACK_DIR)/plugin.mk

--- a/RackSDK.cmake
+++ b/RackSDK.cmake
@@ -1,0 +1,122 @@
+# Mapping of plugin build definitions from the Rack-SDK arch.mk, compile.mk, dep.mk and plugin.mk to CMake.
+
+set(RACK_SDK_VERSION 2.2.2)
+message(STATUS "Load RackSDK.cmake (mapping based on Rack-SDK-${RACK_SDK_VERSION})")
+
+if ("${RACK_SDK_DIR}" STREQUAL "")
+  message(FATAL_ERROR "Path to Rack SDK is missing! Add -DRACK_SDK_DIR=<PATH> to the cmake call.")
+elseif (EXISTS "${RACK_SDK_DIR}/include/rack.hpp")
+  message(STATUS "Using Rack-SDK in '${RACK_SDK_DIR}'")
+else ()
+  message(FATAL_ERROR "Couldn't find 'include/rack.hpp' in '${RACK_SDK_DIR}'")
+endif ()
+
+if ("${PLUGIN_NAME}" STREQUAL "")
+  message(FATAL_ERROR "PLUGIN_NAME variable not set! Add PLUGIN_NAME variable to the project CMakeLists.txt before including RackSDK.cmake.\
+ The PLUGIN_NAME must correspond to the plugin slug, as defined in plugin.json.")
+else ()
+  message(STATUS "Using PLUGIN_NAME '${PLUGIN_NAME}'")
+endif ()
+
+if ("${ADDITIONAL_PLUGIN_DISTRIBUTABLES}" STREQUAL "")
+  message(WARNING "ADDITIONAL_PLUGIN_DISTRIBUTABLES variable not set. For installing additional files into '${PLUGIN_NAME}'\
+   folder add ADDITIONAL_PLUGIN_DISTRIBUTABLES variable to the project CMakeLists.txt before including RackSDK.cmake.")
+endif ()
+
+# Do not change the RACK_PLUGIN_LIB!
+if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm64")
+  set(RACK_PLUGIN_ARCH -arm64)
+endif ()
+set(RACK_PLUGIN_LIB plugin${RACK_PLUGIN_ARCH})
+
+file(GLOB LICENSE LICENSE*)
+set(PLUGIN_DISTRIBUTABLES plugin.json res ${LICENSE} ${ADDITIONAL_PLUGIN_DISTRIBUTABLES})
+
+message(STATUS "PLUGIN_DISTRIBUTABLES: ${PLUGIN_DISTRIBUTABLES}")
+
+add_compile_options(-fvisibility=hidden $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
+# This is needed for Rack for DAWs.
+# Static libs don't usually compiled with -fPIC, but since we're including them in a shared library, it's needed.
+add_compile_options(-fPIC)
+# Generate dependency files alongside the object files
+# Not required with CMake
+#add_compile_options(-MMD -MP)
+
+# Debugger symbols. These are removed with `strip`.
+add_compile_options(-g)
+# Optimization
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message(STATUS "Skipping Optimizations for Debug Build")
+else ()
+  message(STATUS "Enabling Optimizations for Non-Debug Build")
+  add_compile_options(-O3 -funsafe-math-optimizations -fno-omit-frame-pointer)
+endif ()
+# Warnings
+add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+# C++ standard
+if (DEFINED CMAKE_CXX_STANDARD)
+  message(STATUS "Retaining CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+else ()
+  set(CMAKE_CXX_STANDARD 11)
+  message(STATUS "Defaulting CMAKE_CXX_STANDARD to ${CMAKE_CXX_STANDARD}")
+endif ()
+
+add_library(${RACK_PLUGIN_LIB} MODULE)
+set_target_properties(${RACK_PLUGIN_LIB} PROPERTIES PREFIX "")
+
+# Since the plugin's compiler could be a different version than Rack's compiler, link libstdc++ and libgcc statically to avoid ABI issues.
+add_link_options($<$<CXX_COMPILER_ID:GNU>:-static-libstdc++> $<$<PLATFORM_ID:Linux>:-static-libgcc>)
+add_compile_options($<IF:$<STREQUAL:${CMAKE_OSX_ARCHITECTURES},arm64>,-march=armv8-a+fp+simd,-march=nehalem>)
+
+add_library(RackSDK INTERFACE)
+target_include_directories(RackSDK INTERFACE ${RACK_SDK_DIR}/include ${RACK_SDK_DIR}/dep/include)
+target_link_directories(RackSDK INTERFACE ${RACK_SDK_DIR})
+target_link_libraries(RackSDK INTERFACE Rack)
+target_compile_definitions(RackSDK INTERFACE $<IF:$<STREQUAL:${CMAKE_OSX_ARCHITECTURES},arm64>,ARCH_ARM64,ARCH_X64>)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  if (NOT MINGW)
+    message(FATAL_ERROR "Rack plugin development environment is only supported for MSYS2/MinGW")
+  endif ()
+  target_compile_definitions(RackSDK INTERFACE ARCH_WIN _USE_MATH_DEFINES)
+  target_compile_options(RackSDK INTERFACE -municode -Wsuggest-override)
+endif ()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  message(STATUS "Build Mac OSX Plugin for architecture ${CMAKE_OSX_ARCHITECTURES}")
+  target_compile_definitions(RackSDK INTERFACE ARCH_MAC)
+  if (${CMAKE_OSX_ARCHITECTURES} MATCHES "x86_64")
+    add_compile_options(-arch x86_64)
+  endif ()
+  if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm64")
+    add_compile_options(-arch arm64)
+  endif ()
+  set_target_properties(${RACK_PLUGIN_LIB} PROPERTIES SUFFIX ".dylib")
+  set_target_properties(${RACK_PLUGIN_LIB} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif ()
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  target_compile_definitions(RackSDK INTERFACE ARCH_LIN)
+  # This prevents static variables in the DSO (dynamic shared object) from being preserved after dlclose().
+  target_compile_options(RackSDK INTERFACE -fno-gnu-unique)
+  # When Rack loads a plugin, it symlinks /tmp/Rack2 to its system dir, so the plugin can link to libRack.
+  target_compile_options(RackSDK INTERFACE -Wl,-rpath=/tmp/Rack2)
+endif ()
+
+target_link_libraries(${RACK_PLUGIN_LIB} PRIVATE RackSDK)
+
+install(TARGETS ${RACK_PLUGIN_LIB} LIBRARY DESTINATION ${PROJECT_BINARY_DIR}/${PLUGIN_NAME} OPTIONAL)
+install(DIRECTORY ${PROJECT_BINARY_DIR}/${PLUGIN_NAME}/ DESTINATION ${PLUGIN_NAME})
+file(COPY ${PLUGIN_DISTRIBUTABLES} DESTINATION ${PLUGIN_NAME})
+
+set(STABLE_PLUGIN_BUILD_TARGET build_plugin)
+add_custom_target(${STABLE_PLUGIN_BUILD_TARGET})
+add_dependencies(${STABLE_PLUGIN_BUILD_TARGET} ${RACK_PLUGIN_LIB})
+
+# A quick installation target to copy the plugin library and plugin.json into VCV Rack plugin folder for development.
+# CMAKE_INSTALL_PREFIX needs to point to the VCV Rack plugin folder in user documents.
+add_custom_target(${STABLE_PLUGIN_BUILD_TARGET}_quick_install
+        COMMAND cmake -E copy $<TARGET_FILE:${RACK_PLUGIN_LIB}> ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
+        COMMAND cmake -E copy ${CMAKE_SOURCE_DIR}/plugin.json ${CMAKE_INSTALL_PREFIX}/${PLUGIN_NAME}
+        )
+add_dependencies(${STABLE_PLUGIN_BUILD_TARGET}_quick_install ${RACK_PLUGIN_LIB})

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,23 @@
+{
+  "slug": "SvgHelper",
+  "name": "SvgHelper",
+  "version": "2.2.0",
+  "license": "GPL-3.0-or-later",
+  "brand": "MyBrand",
+  "author": "Me",
+  "authorEmail": "",
+  "authorUrl": "",
+  "pluginUrl": "",
+  "manualUrl": "",
+  "sourceUrl": "",
+  "donateUrl": "",
+  "changelogUrl": "",
+  "modules": [
+    {
+      "slug": "SvgHelperModule",
+      "name": "SvgHelperModule",
+      "description": "",
+      "tags": []
+    }
+  ]
+}


### PR DESCRIPTION
I added CMake build system support as request at vcv forum, based on https://github.com/qno/vcv-plugin-cmake-example that is used for the surge-rack.

Generate CMake project with e.g. `cmake -DCMAKE_INSTALL_PREFIX=dist -DRACK_SDK_DIR=/PATH-TO/Rack-SDK ../vcv-svghelper`
